### PR TITLE
Fixes

### DIFF
--- a/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/entity/meta/ImplEntityMetaData.java
+++ b/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/entity/meta/ImplEntityMetaData.java
@@ -61,7 +61,7 @@ public class ImplEntityMetaData implements EntityMetaData {
             return 0;
         }
 
-        return ((byte)this.getProperty(propertyName, EntityMetaPropertyType.BYTE).getValue());
+        return ((Byte)this.getProperty(propertyName, EntityMetaPropertyType.BYTE).getValue());
     }
 
     @Override
@@ -75,7 +75,7 @@ public class ImplEntityMetaData implements EntityMetaData {
             return 0;
         }
 
-        return ((short)this.getProperty(propertyName, EntityMetaPropertyType.SHORT).getValue());
+        return ((Short)this.getProperty(propertyName, EntityMetaPropertyType.SHORT).getValue());
     }
 
     @Override
@@ -89,7 +89,7 @@ public class ImplEntityMetaData implements EntityMetaData {
             return 0;
         }
 
-        return ((int)this.getProperty(propertyName, EntityMetaPropertyType.INTEGER).getValue());
+        return ((Integer)this.getProperty(propertyName, EntityMetaPropertyType.INTEGER).getValue());
     }
 
     @Override
@@ -103,7 +103,7 @@ public class ImplEntityMetaData implements EntityMetaData {
             return 0;
         }
 
-        return ((float)this.getProperty(propertyName, EntityMetaPropertyType.FLOAT).getValue());
+        return ((Float)this.getProperty(propertyName, EntityMetaPropertyType.FLOAT).getValue());
     }
 
     @Override
@@ -117,7 +117,7 @@ public class ImplEntityMetaData implements EntityMetaData {
             return 0;
         }
 
-        return ((long)this.getProperty(propertyName, EntityMetaPropertyType.LONG).getValue());
+        return ((Long)this.getProperty(propertyName, EntityMetaPropertyType.LONG).getValue());
     }
 
     @Override

--- a/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/packets/LevelSoundEventPacket.java
+++ b/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/packets/LevelSoundEventPacket.java
@@ -3,7 +3,7 @@ package io.github.willqi.pizzaserver.server.network.protocol.packets;
 import io.github.willqi.pizzaserver.commons.utils.Vector3;
 import io.github.willqi.pizzaserver.server.network.protocol.data.LevelSound;
 
-public class LevelSoundEventPacket extends BedrockPacket {
+public class LevelSoundEventPacket extends ImplBedrockPacket {
 
     public static final int ID = 0x7b;
 

--- a/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/packets/PlayerActionPacket.java
+++ b/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/packets/PlayerActionPacket.java
@@ -1,10 +1,9 @@
 package io.github.willqi.pizzaserver.server.network.protocol.packets;
 
 import io.github.willqi.pizzaserver.commons.utils.Vector3;
-import io.github.willqi.pizzaserver.server.Server;
 import io.github.willqi.pizzaserver.server.network.protocol.data.PlayerAction;
 
-public class PlayerActionPacket extends BedrockPacket {
+public class PlayerActionPacket extends ImplBedrockPacket {
 
     public static final int ID = 0x24;
 

--- a/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/versions/v419/handlers/V419LevelSoundEventPacketHandler.java
+++ b/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/versions/v419/handlers/V419LevelSoundEventPacketHandler.java
@@ -6,13 +6,13 @@ import io.github.willqi.pizzaserver.commons.utils.Vector3;
 import io.github.willqi.pizzaserver.format.mcworld.utils.VarInts;
 import io.github.willqi.pizzaserver.server.network.protocol.data.LevelSound;
 import io.github.willqi.pizzaserver.server.network.protocol.packets.LevelSoundEventPacket;
-import io.github.willqi.pizzaserver.server.network.protocol.versions.PacketHelper;
-import io.github.willqi.pizzaserver.server.network.protocol.versions.ProtocolPacketHandler;
+import io.github.willqi.pizzaserver.server.network.protocol.versions.BasePacketHelper;
+import io.github.willqi.pizzaserver.server.network.protocol.versions.BaseProtocolPacketHandler;
 import io.netty.buffer.ByteBuf;
 
 import java.util.HashMap;
 
-public class V419LevelSoundEventPacketHandler extends ProtocolPacketHandler<LevelSoundEventPacket> {
+public class V419LevelSoundEventPacketHandler extends BaseProtocolPacketHandler<LevelSoundEventPacket> {
 
     protected final BiMap<LevelSound, Integer> sounds = HashBiMap.create(new HashMap<LevelSound, Integer>() {
         {
@@ -271,7 +271,7 @@ public class V419LevelSoundEventPacketHandler extends ProtocolPacketHandler<Leve
     });
 
     @Override
-    public LevelSoundEventPacket decode(ByteBuf buffer, PacketHelper helper) {
+    public LevelSoundEventPacket decode(ByteBuf buffer, BasePacketHelper helper) {
         LevelSoundEventPacket packet = new LevelSoundEventPacket();
         packet.setSound(sounds.inverse().get(VarInts.readUnsignedInt(buffer)));
         packet.setVector3(new Vector3(
@@ -287,7 +287,7 @@ public class V419LevelSoundEventPacketHandler extends ProtocolPacketHandler<Leve
     }
 
     @Override
-    public void encode(LevelSoundEventPacket packet, ByteBuf buffer, PacketHelper helper) {
+    public void encode(LevelSoundEventPacket packet, ByteBuf buffer, BasePacketHelper helper) {
         VarInts.writeUnsignedInt(buffer, sounds.get(packet.getSound()));
         buffer.writeFloatLE(packet.getVector3().getX());
         buffer.writeFloatLE(packet.getVector3().getY());

--- a/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/versions/v419/handlers/V419PlayerActionPacketHandler.java
+++ b/pizzaserver-server/src/main/java/io/github/willqi/pizzaserver/server/network/protocol/versions/v419/handlers/V419PlayerActionPacketHandler.java
@@ -4,17 +4,16 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import io.github.willqi.pizzaserver.commons.utils.Vector3;
 import io.github.willqi.pizzaserver.format.mcworld.utils.VarInts;
-import io.github.willqi.pizzaserver.server.Server;
+import io.github.willqi.pizzaserver.server.ImplServer;
 import io.github.willqi.pizzaserver.server.network.protocol.data.PlayerAction;
 import io.github.willqi.pizzaserver.server.network.protocol.packets.PlayerActionPacket;
-import io.github.willqi.pizzaserver.server.network.protocol.versions.PacketHelper;
-import io.github.willqi.pizzaserver.server.network.protocol.versions.ProtocolPacketHandler;
-import io.github.willqi.pizzaserver.server.player.Player;
+import io.github.willqi.pizzaserver.server.network.protocol.versions.BasePacketHelper;
+import io.github.willqi.pizzaserver.server.network.protocol.versions.BaseProtocolPacketHandler;
 import io.netty.buffer.ByteBuf;
 
 import java.util.HashMap;
 
-public class V419PlayerActionPacketHandler extends ProtocolPacketHandler<PlayerActionPacket> {
+public class V419PlayerActionPacketHandler extends BaseProtocolPacketHandler<PlayerActionPacket> {
 
 
     protected final BiMap<PlayerAction, Integer> actions = HashBiMap.create(new HashMap<PlayerAction, Integer>(){
@@ -48,12 +47,12 @@ public class V419PlayerActionPacketHandler extends ProtocolPacketHandler<PlayerA
     });
 
     @Override
-    public PlayerActionPacket decode(ByteBuf buffer, PacketHelper helper) {
+    public PlayerActionPacket decode(ByteBuf buffer, BasePacketHelper helper) {
         PlayerActionPacket packet = new PlayerActionPacket();
         packet.setEntityRuntimeID(VarInts.readUnsignedLong(buffer));
         int action = VarInts.readInt(buffer);
         packet.setActionType(actions.inverse().get(action));
-        if(packet.getActionType() == null) Server.getInstance().getLogger().warn("There is an unidentified PlayerAction with an id of " + action + "!");
+        if(packet.getActionType() == null) ImplServer.getInstance().getLogger().warn("There is an unidentified PlayerAction with an id of " + action + "!");
         packet.setVector3(new Vector3(
                 VarInts.readInt(buffer),
                 VarInts.readUnsignedInt(buffer),


### PR DESCRIPTION
For some reason, the packets I made PRs with yesterday weren't refactored to use the new types, also couldn't run the server without having to change the `capture ?` types in the ImplEntityMetaData (JDK 8), so having them as their objects allowed it