### PR TITLE
Resource Pack fixes

### DIFF
--- a/pizzaserver-server/src/main/java/io/github/pizzaserver/server/packs/ImplResourcePackManager.java
+++ b/pizzaserver-server/src/main/java/io/github/pizzaserver/server/packs/ImplResourcePackManager.java
@@ -41,20 +41,20 @@ public class ImplResourcePackManager implements ResourcePackManager {
     public void loadPacks() {
         try {
             Files.list(Paths.get(this.server.getRootDirectory() + "/resourcepacks"))
-                    .map(Path::toFile)
-                    .filter(File::isFile)
-                    .forEach(file -> {
-                        try {
-                            ResourcePack pack = new ZipResourcePack(file);
-                            this.packs.put(pack.getUuid(), pack);
-                            this.server.getLogger().info("Loaded resource pack: " + file.getName());
-                        } catch (IOException exception) {
-                            this.server.getLogger().error("Failed to load resource pack: " + file.getName(), exception);
-                        }
-                    });
+                 .map(Path::toFile)
+                 .filter(File::isFile)
+                 .filter(file -> file.getName().endsWith(".zip") || file.getName().endsWith(".mcpack"))
+                 .forEach(file -> {
+                     try {
+                         ResourcePack pack = new ZipResourcePack(file);
+                         this.packs.put(pack.getUuid(), pack);
+                         this.server.getLogger().info("Loaded resource pack: " + file.getName());
+                     } catch (IOException exception) {
+                         this.server.getLogger().error("Failed to load resource pack: " + file.getName(), exception);
+                     }
+                 });
         } catch (IOException exception) {
             this.server.getLogger().error("Failed to read resourcepacks directory", exception);
         }
     }
-
 }

--- a/pizzaserver-server/src/main/java/io/github/pizzaserver/server/packs/ZipResourcePack.java
+++ b/pizzaserver-server/src/main/java/io/github/pizzaserver/server/packs/ZipResourcePack.java
@@ -111,17 +111,18 @@ public class ZipResourcePack implements ResourcePack {
     private void parsePackData(File file) throws IOException {
         this.dataLength = file.length();
 
-        int chunksLength = (int) Math.ceil((float) this.dataLength / this.getMaxChunkLength());
-        this.chunks = new byte[chunksLength][];
+        int chunkLength = this.getMaxChunkLength();
+        int chunkCount = ((int) this.dataLength + chunkLength - 1) / chunkLength;
+        this.chunks = new byte[chunkCount][];
 
         try (InputStream stream = new FileInputStream(file)) {
-            for (int i = 0; i < chunksLength - 1; i++) {
-                this.chunks[i] = parseDataChunk(stream, new byte[this.getMaxChunkLength()]);
+            for (int i = 0; i < chunkCount - 1; i++) {
+                this.chunks[i] = parseDataChunk(stream, new byte[chunkLength]);
             }
 
             // The last data chunk doesn't use as much space
-            byte[] data = parseDataChunk(stream, new byte[(int) (this.dataLength - (chunksLength - 1) * this.getMaxChunkLength())]);
-            this.chunks[chunksLength - 1] = data;
+            byte[] data = parseDataChunk(stream, new byte[(int) (this.dataLength - (chunkCount - 1) * chunkLength)]);
+            this.chunks[chunkCount - 1] = data;
 
         }
 

--- a/pizzaserver-server/src/main/java/io/github/pizzaserver/server/packs/ZipResourcePack.java
+++ b/pizzaserver-server/src/main/java/io/github/pizzaserver/server/packs/ZipResourcePack.java
@@ -37,7 +37,13 @@ public class ZipResourcePack implements ResourcePack {
 
     @Override
     public int getMaxChunkLength() {
-        return 102400; // While we can technically go higher, the Bedrock Dedicated Server keeps this at 102400.
+        // BDS: 102400
+        final long minChunkLength = 102400;
+
+        // more chunks will cause a clientside error with disconnect
+        final long maxChunks = 99;
+
+        return (int) Math.max((this.getDataLength() + maxChunks) / maxChunks, minChunkLength);
     }
 
     @Override

--- a/pizzaserver-server/src/main/java/io/github/pizzaserver/server/player/handlers/ResourcePackPacketHandler.java
+++ b/pizzaserver-server/src/main/java/io/github/pizzaserver/server/player/handlers/ResourcePackPacketHandler.java
@@ -31,7 +31,13 @@ public class ResourcePackPacketHandler implements BedrockPacketHandler {
         ResourcePacksInfoPacket resourcePacksInfoPacket = new ResourcePacksInfoPacket();
         resourcePacksInfoPacket.setForcedToAccept(this.server.getResourcePackManager().arePacksRequired());
         for (ResourcePack pack : this.server.getResourcePackManager().getPacks().values()) {
-            resourcePacksInfoPacket.getResourcePackInfos().add(new ResourcePacksInfoPacket.Entry(pack.getUuid().toString(), pack.getVersion(), pack.getDataLength(), "", "", "", false, pack.isRayTracingEnabled()));
+            resourcePacksInfoPacket.getResourcePackInfos().add(
+                    new ResourcePacksInfoPacket.Entry(
+                            pack.getUuid().toString(),
+                            pack.getVersion(),
+                            pack.getDataLength(),
+                            "", "", "", false,
+                            pack.isRayTracingEnabled()));
         }
         session.getConnection().sendPacket(resourcePacksInfoPacket);
     }
@@ -41,10 +47,6 @@ public class ResourcePackPacketHandler implements BedrockPacketHandler {
     public boolean handle(ResourcePackClientResponsePacket packet) {
         switch (packet.getStatus()) {
             case SEND_PACKS:
-
-                this.server.getLogger().debug("yup");
-
-
                 // Create list of all packs' info of the packs the client does not have.
                 for (String packId : packet.getPackIds()) {
                     UUID uuid = UUID.fromString(packId.split("_")[0]);


### PR DESCRIPTION
- Fixed chunk size calculation using sketchy float arithmetic
- Vary chunk size to allow for >10mB size packs while keeping chunk count below allowed maximum
- Add validation for incremental chunk index requests (as the vanilla client should always send)
- Add download queue to work around [this bug](https://bugs.mojang.com/browse/MCPE-151654)