### PR TITLE
fix float math in integer context

### DIFF
--- a/pizzaserver-commons/src/main/java/io/github/pizzaserver/commons/utils/NumberUtils.java
+++ b/pizzaserver-commons/src/main/java/io/github/pizzaserver/commons/utils/NumberUtils.java
@@ -10,4 +10,17 @@ public class NumberUtils {
         return Math.abs(a - b) < 0.001d;
     }
 
+    /**
+     * Calculates the Base-2 logarithm of {@code bits}. If {@code bits} is zero, zero is returned.
+     *
+     * @param bits x
+     * @return {@code ceil(log2(x))}
+     */
+    public static int log2Ceil(int bits) {
+        if (bits == 0) {
+            return 0;
+        }
+        return 31 - Integer.numberOfLeadingZeros(bits);
+    }
+
 }

--- a/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/utils/BedrockNetworkUtils.java
+++ b/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/utils/BedrockNetworkUtils.java
@@ -1,8 +1,12 @@
 package io.github.pizzaserver.format.utils;
 
+import io.github.pizzaserver.commons.utils.NumberUtils;
 import io.github.pizzaserver.format.MinecraftSerializationHandler;
 import io.github.pizzaserver.format.dimension.chunks.BedrockBiomeMap;
-import io.github.pizzaserver.format.dimension.chunks.subchunk.*;
+import io.github.pizzaserver.format.dimension.chunks.subchunk.BedrockSubChunk;
+import io.github.pizzaserver.format.dimension.chunks.subchunk.BedrockSubChunkBiomeMap;
+import io.github.pizzaserver.format.dimension.chunks.subchunk.BlockLayer;
+import io.github.pizzaserver.format.dimension.chunks.subchunk.BlockPaletteEntry;
 import io.github.pizzaserver.format.dimension.chunks.subchunk.utils.Palette;
 import io.netty.buffer.ByteBuf;
 
@@ -11,7 +15,8 @@ import java.util.Set;
 
 public class BedrockNetworkUtils {
 
-    private BedrockNetworkUtils() {}
+    private BedrockNetworkUtils() {
+    }
 
     public static void serializeSubChunk(ByteBuf buffer, BedrockSubChunk subChunk, MinecraftSerializationHandler serializationHandler) {
         buffer.writeByte(8);    // Convert to version 8 regardless of v1 or v8
@@ -22,9 +27,10 @@ public class BedrockNetworkUtils {
     }
 
     public static void serializeBlockLayer(ByteBuf buffer, BlockLayer blockLayer, MinecraftSerializationHandler serializationHandler) {
-        int bitsPerBlock = Math.max((int) Math.ceil(Math.log(blockLayer.getPalette().getEntries().size()) / Math.log(2)), 1);
+        int bitsPerBlock = Math.max(NumberUtils.log2Ceil(blockLayer.getPalette().getEntries().size()), 1);
         int blocksPerWord = 32 / bitsPerBlock;
-        int wordsPerChunk = (int) Math.ceil(4096d / blocksPerWord);
+        // integral ceiling division
+        int wordsPerChunk = (4096 + blocksPerWord - 1) / blocksPerWord;
 
         buffer.writeByte((bitsPerBlock << 1) | 1);
 
@@ -71,7 +77,7 @@ public class BedrockNetworkUtils {
                 throw new IOException("biome sub chunk has no biomes present");
             }
 
-            int bitsPerBlock = (int) Math.ceil(Math.log(subChunkBiomeMap.getPalette().getEntries().size()) / Math.log(2));
+            int bitsPerBlock = NumberUtils.log2Ceil(subChunkBiomeMap.getPalette().getEntries().size());
             int blocksPerWord = 0;
             int wordsPerChunk = 0;
 
@@ -83,7 +89,8 @@ public class BedrockNetworkUtils {
 
             if (bitsPerBlock > 0) {
                 blocksPerWord = 32 / bitsPerBlock;
-                wordsPerChunk = (int) Math.ceil(4096d / blocksPerWord);
+                // integral ceiling division
+                wordsPerChunk = (4096 + blocksPerWord - 1) / blocksPerWord;
             }
 
             buffer.writeByte((bitsPerBlock << 1) | 1);

--- a/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/utils/BedrockNetworkUtils.java
+++ b/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/utils/BedrockNetworkUtils.java
@@ -27,7 +27,7 @@ public class BedrockNetworkUtils {
     }
 
     public static void serializeBlockLayer(ByteBuf buffer, BlockLayer blockLayer, MinecraftSerializationHandler serializationHandler) {
-        int bitsPerBlock = Math.max(NumberUtils.log2Ceil(blockLayer.getPalette().getEntries().size()), 1);
+        int bitsPerBlock = NumberUtils.log2Ceil(blockLayer.getPalette().getEntries().size()) + 1;
         int blocksPerWord = 32 / bitsPerBlock;
         // integral ceiling division
         int wordsPerChunk = (4096 + blocksPerWord - 1) / blocksPerWord;
@@ -77,7 +77,7 @@ public class BedrockNetworkUtils {
                 throw new IOException("biome sub chunk has no biomes present");
             }
 
-            int bitsPerBlock = NumberUtils.log2Ceil(subChunkBiomeMap.getPalette().getEntries().size());
+            int bitsPerBlock = NumberUtils.log2Ceil(subChunkBiomeMap.getPalette().getEntries().size()) + 1;
             int blocksPerWord = 0;
             int wordsPerChunk = 0;
 


### PR DESCRIPTION
Previously, float math was used to approximate ceil(log2(x)) and rounding up divison in integers contexts.