### PR TITLE
Fix chunk float math, add persistent chunk encoding

### DIFF
--- a/pizzaserver-server/src/main/java/io/github/pizzaserver/server/level/world/chunks/ImplChunk.java
+++ b/pizzaserver-server/src/main/java/io/github/pizzaserver/server/level/world/chunks/ImplChunk.java
@@ -497,7 +497,7 @@ public class ImplChunk implements Chunk {
                 subChunkCount = ChunkUtils.getSubChunkCount(this.chunk);
 
                 for (int i = -4; i < subChunkCount - 4; i++) {
-                    BedrockNetworkUtils.serializeSubChunk(buffer, this.chunk.getSubChunk(i), (BaseMinecraftVersion) player.getVersion());
+                    BedrockNetworkUtils.serializeSubChunk(buffer, this.chunk.getSubChunk(i), false, (BaseMinecraftVersion) player.getVersion());
                 }
 
                 // Write biomes

--- a/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/provider/mcworld/utils/MCWorldFormatUtils.java
+++ b/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/provider/mcworld/utils/MCWorldFormatUtils.java
@@ -107,6 +107,7 @@ public class MCWorldFormatUtils {
         int blocksPerWord = 32 / bitsPerBlock;
         int wordsPerChunk = (4096 + blocksPerWord - 1) / blocksPerWord;
 
+        // 1 bit is not set = we save block states
         buffer.writeByte(bitsPerBlock << 1);
 
         int pos = 0;
@@ -351,7 +352,7 @@ public class MCWorldFormatUtils {
                     wordsPerChunk = (4096 + blocksPerWord - 1) / blocksPerWord;
                 }
 
-                buffer.writeByte(bitsPerBlock << 1);
+                buffer.writeByte((bitsPerBlock << 1) | 1);
 
                 int pos = 0;
                 for (int i = 0; i < wordsPerChunk; i++) {

--- a/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/utils/BedrockNetworkUtils.java
+++ b/pizzaserver-worldfile/src/main/java/io/github/pizzaserver/format/utils/BedrockNetworkUtils.java
@@ -118,7 +118,7 @@ public class BedrockNetworkUtils {
                 wordsPerChunk = (4096 + blocksPerWord - 1) / blocksPerWord;
             }
 
-            buffer.writeByte(bitsPerBlock << 1);
+            buffer.writeByte((bitsPerBlock << 1) | 1);
 
             int pos = 0;
             for (int i = 0; i < wordsPerChunk; i++) {


### PR DESCRIPTION
There was still some float math left over in chunk encoding for disk and network.
To prepare for future client-side chunk caching support, I also added the persistent chunk format by encoding block state NBT into the palette instead of runtime ids.